### PR TITLE
Add neofetch, autojump, & sdkman

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is for my personal use. Feel free to use any of these scripts, but run them
 at your own discretion. I am not responsible for any effects of these scripts
 on your machine.
 
-# Installation
+## Installation
 
 Each "supported" platform has things you need to run before you clone and run
 things.
@@ -39,16 +39,16 @@ git clone https://github.com/ksmithut/.dotfiles
 .dotfiles/bin/dotfiles setup
 ```
 
-# Supported/Tested installations
+## Supported/Tested installations
 
 - macOS
 - Ubuntu (On Dell XPS)
 - Pop!\_OS (On Dell XPS)
 - Debian (Linux on ChromeOS)
 
-# Create Installation Media
+## Create Installation Media
 
-## macOS
+### macOS
 
 [Apple Docs](createinstallmedia)
 
@@ -70,16 +70,16 @@ want to back up all your stuff and shutdown the computer. When you restart, hold
 down the option key with the USB drive plugged in and select your install media
 as the boot drive and continue with installation there.
 
-## Ubuntu and Pop!\_OS
+### Ubuntu and Pop!\_OS
 
 Download the ISOs from their respective sites and write the images to a bootable
 USB drive using something like [balenaEtcher](https://www.balena.io/etcher/).
 
-## Debian (ChromeOS)
+### Debian (ChromeOS)
 
 Just enable Linux App (Beta) in the settings
 
-# Structure
+## Structure
 
 The directory structure was mostly modeled after [cowboy's dotfiles][cowboy].
 
@@ -102,9 +102,9 @@ The directory structure was mostly modeled after [cowboy's dotfiles][cowboy].
 - `source/` All files in here will be included upon every new terminal session.
   Use this for things like aliases, functions, and customizing the bash prompt.
 
-# Notes
+## Notes
 
-## Dell XPS 15 9560 for Ubuntu (Not Pop!\_OS)
+### Dell XPS 15 9560 for Ubuntu (Not Pop!\_OS)
 
 If you're installing Ubuntu, you'll need to add a boot flag on install.
 Add `nouveau.modeset=0` to boot options (by pressing `e` when selecting a boot
@@ -142,7 +142,7 @@ sudo update-grub2
 
 Preferred keyboard shortcuts (Might apply to Pop!\_OS)
 
-```
+```sh
 # Keyboard shortcuts
 # ==================
 # Prevent gnome resetting keyboard setting in X
@@ -182,7 +182,7 @@ Open up about:config
 
 - change 'layout.css.devPixelsPerPx' to 1.25 for global scaling
 
-# Pixelbook
+## Pixelbook
 
 I also like to change the terminal configuration to work with powerline fonts:
 
@@ -190,7 +190,7 @@ I also like to change the terminal configuration to work with powerline fonts:
 2. Change `font-family` to `"Source Code Pro", monospace`
 3. Change `user-css` to `https://cdn.rawgit.com/wernight/powerline-web-fonts/e4d967ca4f95d9fa0cf1d51afed2e5a5927d759e/PowerlineFonts.css`
 
-# Windows
+## Windows
 
 Obviously, this is meant for mac/linux based on the bash usage, but I'd like to
 have some scripts ready to setup my gaming machines as well. Unfortunately, I've
@@ -225,7 +225,7 @@ than local time.
 >
 >     sc config w32time start= disabled
 
-# Backup
+## Backup
 
 Before you begin a clean install, you may wish to backup other non-dotfile
 related files (such as pictures and documents and such). There is a backup

--- a/init/10_debian_apt.sh
+++ b/init/10_debian_apt.sh
@@ -6,6 +6,7 @@ sudo add-apt-repository -y ppa:alexlarsson/flatpak
 sudo apt-get update -y
 sudo apt-get upgrade -y
 sudo apt-get install -y \
+  autojump \
   build-essential \
   buku \
   curl \
@@ -13,6 +14,7 @@ sudo apt-get install -y \
   gvfs-bin \
   jq \
   libgconf-2-4 \
+  neofetch \
   oathtool \
   python \
   ruby \
@@ -85,3 +87,7 @@ sudo dpkg -i "$DOTFILES/caches/installers/erlang.deb"
 sudo apt-get update
 sudo apt-get install -y esl-erlang
 sudo apt-get install -y elixir
+
+# SDKMan!
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/init/10_ubuntu_apt.sh
+++ b/init/10_ubuntu_apt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Ubuntu-only stuff. Abort if macOS.
+# Ubuntu/Pop!_OS-only stuff. Abort if macOS.
 is_ubuntu || return 1
 
 # Note that this is pretty fragile. This is basically going through and parsing
@@ -33,6 +33,7 @@ sudo apt-get update -y
 sudo apt-get upgrade -y
 
 sudo apt-get install -y \
+  autojump \
   build-essential \
   buku \
   curl \
@@ -42,6 +43,7 @@ sudo apt-get install -y \
   gvfs-bin \
   jq \
   libgconf-2-4 \
+  neofetch \
   oathtool \
   python \
   ruby \
@@ -117,3 +119,7 @@ sudo dpkg -i "$DOTFILES/caches/installers/erlang.deb"
 sudo apt-get update
 sudo apt-get install -y esl-erlang
 sudo apt-get install -y elixir
+
+# SDKMan!
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh" 

--- a/link/.Brewfile
+++ b/link/.Brewfile
@@ -1,7 +1,8 @@
-cask_args appdir: '/Applications'
++----------------------cask_args appdir: '/Applications'
 tap 'homebrew/services'
 
 # Tools
+brew 'autojump'
 brew 'bash'
 brew 'buku'
 brew 'elixir'
@@ -17,6 +18,7 @@ brew 'kubeseal'
 brew 'kustomize'
 brew 'pinentry-mac'
 brew 'python3'
+brew 'sdkman'
 brew 'shellcheck'
 brew 'siege'
 brew 'skaffold'

--- a/source/10_env.sh
+++ b/source/10_env.sh
@@ -22,3 +22,6 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export EDITOR=vi
 # https://github.com/npm/npm/issues/11696
 export COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+
+# dotnet telemetry optout
+export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/source/20_zsh_config.sh
+++ b/source/20_zsh_config.sh
@@ -74,6 +74,7 @@ plugins=(
   gpg-agent
   ssh-agent
   kubectl
+  autojump
 )
 
 mac_plugins=(
@@ -98,6 +99,11 @@ source "$ZSH/oh-my-zsh.sh"
 
 autoload -U add-zsh-hook
 add-zsh-hook -Uz chpwd (){ la; }
+
+# autojump init per policy reasons
+if is_debian || is_ubuntu; then
+  source /usr/share/autojump/autojump.sh
+fi
 
 # https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/agnoster.zsh-theme
 build_prompt() {

--- a/source/30_aliases.sh
+++ b/source/30_aliases.sh
@@ -165,6 +165,9 @@ if is_ubuntu || is_debian; then
   }
 fi
 
+  # show off
+  alias neo='clear && neofetch'
+
 function ksmithut () {
   echo -e '
   \033[38;5;247m⣿⣿⣿⣿⣿⣿⣿⡇⠀\033[38;5;075m⢀⣼⣿⣿⣿⣿⣿⣿⣿⣿⠋

--- a/source/90_apps.sh
+++ b/source/90_apps.sh
@@ -1,0 +1,3 @@
+# SDKMan requires it be sourced last
+export SDKMAN_DIR="$HOME/.sdkman"
+[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh" 


### PR DESCRIPTION
It took me awhile to get back on my laptop, but I was able to pull down your changes (which I'm glad you updated some things) :+1:. I had to push to a new branch though as I kept getting errors with fast forwarding and reset/rebase wasn't working. I put my old computer in a case and threw Pop!_OS on it (Arch Linux had video issues...) and I wanted to utilize your **.dotfiles**. Anyways, here's the new PR!

Updated the Readme to have proper headings (per markdown-lint)

Added the following:

SDKMan!
Basically nvm for sdks. Can install multiple java versions (and more) and switch between them easily.
autojump
I'm surprised you haven't experience this one yet! Faster terminal navigation. ie: j code jumps to ~/Code wherever you are. j dot goes to ~/.dotfiles but you have to visit them at least once for it to learn.
neofetch
Ever browse /r/unixporn?
PS- this failed here so a lot of stuff didn't get installed when I installed Pop!_os 18.10. I've since upgraded to 19.04 since 18.10 is EOL in a couple weeks and my dwm broke so I have to use TTY to login disappointed...so I'll be reinstalling soon.

function is_pop_desktop() {
  dpkg -l pop-desktop >/dev/null 2>&1 || return 1  # returns 1 in pop!_os
  dpkg -l pop-default-settings >/dev/null 2>&1 || return 1 # returns details
}

 ~/.dotfiles $ dpkg -l pop-desktop >/dev/null 2>&1 || return 1
 ✘ ~/.dotfiles $ dpkg -l pop-default-settings >/dev/null 2>&1 || return 1
 ~/.dotfiles $